### PR TITLE
Fix boolean casting for cluster option

### DIFF
--- a/src/Livewire/LivewireMap.php
+++ b/src/Livewire/LivewireMap.php
@@ -60,7 +60,7 @@ class LivewireMap extends Component
         $this->height = $height ?? ($cfg['default_height'] ?? '400px');
 
         $defaultUseClusters = (bool) ($cfg['use_clusters'] ?? false);
-        $this->useClusters = is_bool($useClusters) ? $useClusters : $defaultUseClusters;
+        $this->useClusters = $this->toBoolean($useClusters, $defaultUseClusters);
 
         $this->mapOptions = is_array($mapOptions) ? $mapOptions : (is_array($cfg['map_options'] ?? null) ? $cfg['map_options'] : []);
         $this->clusterOptions = is_array($clusterOptions) ? $clusterOptions : (is_array($cfg['cluster_options'] ?? null) ? $cfg['cluster_options'] : []);
@@ -100,6 +100,22 @@ class LivewireMap extends Component
             'useClusters' => $this->useClusters,
             'clusterOptions' => $this->clusterOptions,
         ]);
+    }
+
+    protected function toBoolean($value, bool $default): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_string($value) || is_numeric($value)) {
+            $filtered = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            if ($filtered !== null) {
+                return $filtered;
+            }
+        }
+
+        return $default;
     }
 
     protected function normalizeMarkers($markers): array

--- a/tests/Feature/UseClustersCastTest.php
+++ b/tests/Feature/UseClustersCastTest.php
@@ -1,0 +1,19 @@
+<?php
+
+use Sdw\LivewireMaps\Livewire\LivewireMap;
+
+it('casts various useClusters values to boolean', function () {
+    config(['livewire-maps.use_clusters' => true]);
+
+    $cmpFalse = new LivewireMap();
+    $cmpFalse->mount(useClusters: 'false');
+    expect($cmpFalse->useClusters)->toBeFalse();
+
+    $cmpTrue = new LivewireMap();
+    $cmpTrue->mount(useClusters: 'true');
+    expect($cmpTrue->useClusters)->toBeTrue();
+
+    $cmpNumeric = new LivewireMap();
+    $cmpNumeric->mount(useClusters: 0);
+    expect($cmpNumeric->useClusters)->toBeFalse();
+});


### PR DESCRIPTION
## Summary
- ensure `useClusters` accepts string and numeric boolean values
- add test covering `useClusters` casting

## Testing
- `composer test` *(fails: pest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad717238148331a67c650f6ee4c33d