### PR TITLE
Fix draw events by listening on window

### DIFF
--- a/resources/views/livewire-map.blade.php
+++ b/resources/views/livewire-map.blade.php
@@ -344,6 +344,15 @@
                     startDrawing(instance, d.type || null);
                 });
 
+                // Also listen on window for draw events so parents can dispatch globally
+                window.addEventListener('lw-map:draw', function(e) {
+                    // Avoid handling twice when event targets this element directly
+                    if (e && e.target && e.target.id === domId) { return; }
+                    var d = (e && e.detail) || {};
+                    if (d.id && d.id !== domId) return;
+                    startDrawing(instance, d.type || null);
+                });
+
                 // ---- (Optioneel) Livewire bus — UIT laten als je element‑events gebruikt
                 function subscribeLivewireBus() {
                     try {


### PR DESCRIPTION
## Summary
- listen for `lw-map:draw` on `window` to allow parent components to trigger drawing

## Testing
- `composer test` *(fails: pest: not found)*
- `composer install` *(fails: failed to download symfony/polyfill-mbstring: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7450a2d88331ac062d611112fc66