### PR TITLE
Broaden queueInit detection when bundle loads

### DIFF
--- a/resources/js/livewire-maps.js
+++ b/resources/js/livewire-maps.js
@@ -195,6 +195,8 @@
     if (document.readyState === 'complete') setTimeout(processQueue, 1000);
     else window.addEventListener('load', () => setTimeout(processQueue, 0), { once: true });
   };
+  LW.queueInit.__isShim = false;
+  try { LW.__queueInitShim = null; } catch (_) {}
 
   // Listen for server → browser updates from Livewire PHP
   try {
@@ -229,4 +231,6 @@
       });
     }
   } catch (_) {}
+  // Attempt to process any queued maps that were pushed before this script executed
+  try { processQueue(); } catch (_) {}
 })();

--- a/resources/views/scripts.blade.php
+++ b/resources/views/scripts.blade.php
@@ -5,42 +5,45 @@
 <script>
 	window.__LW_MAPS = window.__LW_MAPS || { instances: {}, queue: [], ready: false };
 
-	(function() {
-		var LW = window.__LW_MAPS;
+        (function() {
+                var LW = window.__LW_MAPS;
 
-		// 1) Shim die items pusht vóór het bundle geladen is
-		if (typeof LW.queueInit !== 'function') {
-			LW.queueInit = function(domId, config) {
-				try { LW.queue.push({ domId: String(domId), config: config || {} }); } catch (_) {}
-			};
-		}
+                // 1) Shim die items pusht vóór het bundle geladen is
+                if (typeof LW.queueInit !== 'function' || LW.queueInit.__isShim === true) {
+                        var shim = function(domId, config) {
+                                try { LW.queue.push({ domId: String(domId), config: config || {} }); } catch (_) {}
+                        };
+                        shim.__isShim = true;
+                        LW.__queueInitShim = shim;
+                        LW.queueInit = shim;
+                }
 
-		// 2) Poller die wacht op de échte queueInit uit het bundle en daarna de bestaande queue drained
-		if (!LW.__bootDrainPoller) {
-			LW.__bootDrainPoller = setInterval(function() {
-				try {
-					// Als het bundle geladen is, zal LW.queueInit opnieuw gedefinieerd zijn (niet onze shim-referentie)
-					var isReal = false;
-					try {
-						// simpele heuristiek: echte implementatie heeft timers en meer logica; maar vooral: andere referentie
-						isReal = !!LW.queueInit && LW.queueInit.toString().indexOf('processQueue') !== -1;
-					} catch(_) {}
+                // 2) Poller die wacht op de échte queueInit uit het bundle en daarna de bestaande queue drained
+                if (!LW.__bootDrainPoller) {
+                        LW.__bootDrainPoller = setInterval(function() {
+                                try {
+                                        // Als het bundle geladen is, zal LW.queueInit opnieuw gedefinieerd zijn (niet onze shim)
+                                        var current = LW.queueInit;
+                                        var shimRef = LW.__queueInitShim;
+                                        var isReal = (typeof current === 'function')
+                                                && current.__isShim !== true
+                                                && (!shimRef || current !== shimRef);
 
-					if (isReal) {
-						// Drain bestaande queue via de echte queueInit zodat processQueue/timers worden geactiveerd
-						var items = LW.queue.slice();
-						LW.queue = [];
-						items.forEach(function(item){
-							try { LW.queueInit(item.domId, item.config); } catch(_) {}
-						});
+                                        if (isReal) {
+                                                // Drain bestaande queue via de echte queueInit zodat processQueue/timers worden geactiveerd
+                                                var items = LW.queue.slice();
+                                                LW.queue = [];
+                                                items.forEach(function(item){
+                                                        try { LW.queueInit(item.domId, item.config); } catch(_) {}
+                                                });
 
-						clearInterval(LW.__bootDrainPoller);
-						LW.__bootDrainPoller = null;
-					}
-				} catch(_) {}
-			}, 50);
-		}
-	})();
+                                                clearInterval(LW.__bootDrainPoller);
+                                                LW.__bootDrainPoller = null;
+                                        }
+                                } catch(_) {}
+                        }, 50);
+                }
+        })();
 </script>
 
 @php


### PR DESCRIPTION
## Summary
- persist a reference to the inline queueInit shim so we can detect when the real bundle overwrites it
- fall back to identity checks when looking for the real queueInit implementation so older bundles without the new flag still work
- clear the stored shim reference inside the JavaScript bundle when the real queueInit function is registered

## Testing
- composer test *(fails: pest executable missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d267fd8460833198fce1d47406445e