### PR TITLE
Load MarkerClusterer before bundle

### DIFF
--- a/resources/views/scripts.blade.php
+++ b/resources/views/scripts.blade.php
@@ -56,6 +56,8 @@
     $cdnUrl = $cfg['cdn_url'] ?? null;
     $viteEntry = $cfg['vite_entry'] ?? 'resources/js/livewire-maps.js';
     $mixPath = $cfg['mix_path'] ?? '/vendor/livewire-maps/livewire-maps.js';
+    $clustererSrc = 'https://cdn.jsdelivr.net/npm/@googlemaps/markerclusterer/dist/index.min.js';
+    $loadsClusterer = $assetDriver !== 'none';
 @endphp
 
 {{-- Optionally include Google Maps API --}}
@@ -69,6 +71,9 @@
 @endif
 
 {{-- Load package JS based on configured asset driver --}}
+@if($loadsClusterer)
+    <script src="{{ $clustererSrc }}"></script>
+@endif
 @switch($assetDriver)
     @case('vite')
         @vite($viteEntry)


### PR DESCRIPTION
## Summary
- load the Google MarkerClusterer library from jsDelivr when the directive manages package assets
- ensure the clustering script is included before any package JS so the global is ready for the bundle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d28f6ddfb48331a8bb84db6acfc2d1